### PR TITLE
Aus - moving  "get_os_name" func to rsutils library

### DIFF
--- a/common/model-views.cpp
+++ b/common/model-views.cpp
@@ -28,6 +28,8 @@
 #include "imgui-fonts-monofont.hpp"
 
 #include "os.h"
+#include <rsutils/os/os.h>
+
 
 #include "metadata-helper.h"
 #include "calibration-model.h"
@@ -347,7 +349,7 @@ namespace rs2
         ss << "| | |\n";
         ss << "|---|---|\n";
         ss << "|**librealsense**|" << api_version_to_string(rs2_get_api_version(&e)) << (is_debug() ? " DEBUG" : " RELEASE") << "|\n";
-        ss << "|**OS**|" << get_os_name() << "|\n";
+        ss << "|**OS**|" << rsutils::get_os_name() << "|\n";
 
         for (auto& dm : devices)
         {

--- a/common/os.cpp
+++ b/common/os.cpp
@@ -360,24 +360,7 @@ Some auxillary functionalities might be affected. Please report this message if 
             i++, j++);
         return j == prefix.end();
     }
-
-    std::string get_os_name()
-    {
-#ifdef _WIN32
-        return "Windows";
-#else
-#ifdef __APPLE__
-        return "Mac OS";
-#else
-#ifdef __linux__
-        return "Linux";
-#else
-        return "Unknown";
-#endif
-#endif
-#endif
-    }
-    
+ 
     bool is_debug()
     {
 #ifndef NDEBUG

--- a/common/os.h
+++ b/common/os.h
@@ -65,7 +65,5 @@ namespace rs2
 
     std::string url_encode(const std::string &value);
 
-    std::string get_os_name();
-
     bool is_debug();
 }

--- a/common/sw-update/versions-db-manager.cpp
+++ b/common/sw-update/versions-db-manager.cpp
@@ -8,6 +8,7 @@
 #include "json.hpp"
 #include "versions-db-manager.h"
 #include <types.h>
+#include <rsutils/os/os.h>
 
 namespace rs2
 {
@@ -16,27 +17,6 @@ namespace rs2
     {
         using json = nlohmann::json;
         using namespace http;
-
-        // Get current platform
-        constexpr const char* PLATFORM =
-
-#ifdef _WIN64
-            "Windows amd64";
-#elif _WIN32
-            "Windows x86";
-#elif __linux__
-#ifdef __arm__
-            "Linux arm";
-#else
-            "Linux amd64";
-#endif
-#elif __APPLE__
-            "Mac OS";
-#elif __ANDROID__
-            "Linux arm";
-#else
-            "";
-#endif
 
         query_status_type versions_db_manager::query_versions(const std::string &device_name, component_part_type component, const update_policy_type policy, version& out_version)
         {
@@ -47,7 +27,7 @@ namespace rs2
                 return DB_LOAD_FAILURE;
             }
 
-            std::string platform(PLATFORM);
+            std::string platform = rsutils::get_platform_name();
 
             std::string up_str(to_string(policy));
             std::string comp_str(to_string(component));
@@ -77,7 +57,7 @@ namespace rs2
             // Check if server versions are loaded
             if (!_server_versions_loaded) return false;
 
-            std::string platform = PLATFORM;
+            std::string platform = rsutils::get_platform_name();
 
             std::string component_str(to_string(component));
 

--- a/common/windows-app-bootstrap.cpp
+++ b/common/windows-app-bootstrap.cpp
@@ -15,6 +15,7 @@
 #include <iostream>
 #include <csignal>
 
+#include <rsutils/os/os.h>
 #include "os.h"
 #include "metadata-helper.h"
 #include "rendering.h"
@@ -98,7 +99,7 @@ void report_error(std::string error)
         ss << "| | |\n";
         ss << "|---|---|\n";
         ss << "|**librealsense**|" << rs2::api_version_to_string(rs2_get_api_version(&e)) << (rs2::is_debug() ? " DEBUG" : " RELEASE") << "|\n";
-        ss << "|**OS**|" << rs2::get_os_name() << "|\n\n";
+        ss << "|**OS**|" << rsutils::get_os_name() << "|\n\n";
         ss << "Intel RealSense Viewer / Depth Quality Tool has crashed with the following error message:\n";
         ss << "```\n";
         ss << error;

--- a/include/librealsense2/h/rs_aus.h
+++ b/include/librealsense2/h/rs_aus.h
@@ -11,9 +11,9 @@
 
 #ifdef __cplusplus
 extern "C" {
-#endif
+    #endif
 
-#include "rs_types.h"
+    #include "rs_types.h"
 
     /**
     * set counter to be value. if no value provided, counter will be asigned to 0
@@ -22,7 +22,7 @@ extern "C" {
     * \param[out] error    if non-null, receives any error that occurs during this call, otherwise, errors are ignored
     * \return
     */
-    void rs2_aus_set(const char* counter, int value, rs2_error** error);
+    void rs2_aus_set( const char * counter, int value, rs2_error ** error );
 
     /**
     * increase counter by 1
@@ -30,7 +30,7 @@ extern "C" {
     * \param[out] error    if non-null, receives any error that occurs during this call, otherwise, errors are ignored
     * \return
     */
-    void rs2_aus_increment(const char* counter, rs2_error** error);
+    void rs2_aus_increment( const char * counter, rs2_error ** error );
 
     /**
     * decrease counter by 1
@@ -46,7 +46,7 @@ extern "C" {
     * \param[out] error    if non-null, receives any error that occurs during this call, otherwise, errors are ignored
     * \return     counter value
     */
-    long rs2_aus_get(const char* counter, rs2_error** error);
+    long rs2_aus_get( const char * counter, rs2_error ** error );
 
     /**
     * starts timer
@@ -54,7 +54,7 @@ extern "C" {
     * \param[out] error    if non-null, receives any error that occurs during this call, otherwise, errors are ignored
     * \return
     */
-    void rs2_aus_start(const char* timer, rs2_error** error);
+    void rs2_aus_start( const char * timer, rs2_error ** error );
 
     /**
     * stops timer
@@ -62,7 +62,7 @@ extern "C" {
     * \param[out] error    if non-null, receives any error that occurs during this call, otherwise, errors are ignored
     * \return
     */
-    void rs2_aus_stop(const char* timer, rs2_error** error);
+    void rs2_aus_stop( const char * timer, rs2_error ** error );
 
 
     /**
@@ -70,7 +70,7 @@ extern "C" {
     * \param[out] error    if non-null, receives any error that occurs during this call, otherwise, errors are ignored
     * \return     struct that includes vector with counters names as strings
     */
-    const rs2_strings_list* rs2_aus_get_counters_list(rs2_error** error);
+    const rs2_strings_list * rs2_aus_get_counters_list( rs2_error ** error );
 
     /**
     * get size of rs2_aus_counters_names buffer
@@ -78,7 +78,7 @@ extern "C" {
     * \param[out] error    if non-null, receives any error that occurs during this call, otherwise, errors are ignored
     * \return     size of rs2_aus_counters_names buffer
     */
-    int rs2_aus_get_counters_list_size(const rs2_strings_list* buffer, rs2_error** error);
+    int rs2_aus_get_counters_list_size( const rs2_strings_list * buffer, rs2_error ** error );
 
     /**
     * delete rs2_aus_counters_names buffer
@@ -86,7 +86,7 @@ extern "C" {
     * \param[out] error    if non-null, receives any error that occurs during this call, otherwise, errors are ignored
     * \return
     */
-    void rs2_aus_delete_counters_list(const rs2_strings_list* buffer);
+    void rs2_aus_delete_counters_list( const rs2_strings_list * buffer );
 
     /**
     * Retrieve char array from rs2_aus_counters_names buffer at index i
@@ -94,8 +94,9 @@ extern "C" {
     * \param[out] error   if non-null, receives any error that occurs during this call, otherwise, errors are ignored
     * \return     char* from buffer at index i
     */
-    const char* rs2_aus_get_counter_data(const rs2_strings_list* buffer, int i, rs2_error** error);
+    const char * rs2_aus_get_counter_data( const rs2_strings_list * buffer, int i, rs2_error ** error );
 
+    const rs2_raw_data_buffer * rs2_aus_receive_json_data(rs2_error ** error);
 
 #ifdef __cplusplus
 }

--- a/include/librealsense2/h/rs_aus.h
+++ b/include/librealsense2/h/rs_aus.h
@@ -11,9 +11,9 @@
 
 #ifdef __cplusplus
 extern "C" {
-    #endif
+#endif
 
-    #include "rs_types.h"
+#include "rs_types.h"
 
     /**
     * set counter to be value. if no value provided, counter will be asigned to 0
@@ -22,7 +22,7 @@ extern "C" {
     * \param[out] error    if non-null, receives any error that occurs during this call, otherwise, errors are ignored
     * \return
     */
-    void rs2_aus_set( const char * counter, int value, rs2_error ** error );
+    void rs2_aus_set(const char* counter, int value, rs2_error** error);
 
     /**
     * increase counter by 1
@@ -30,7 +30,7 @@ extern "C" {
     * \param[out] error    if non-null, receives any error that occurs during this call, otherwise, errors are ignored
     * \return
     */
-    void rs2_aus_increment( const char * counter, rs2_error ** error );
+    void rs2_aus_increment(const char* counter, rs2_error** error);
 
     /**
     * decrease counter by 1
@@ -38,7 +38,7 @@ extern "C" {
     * \param[out] error    if non-null, receives any error that occurs during this call, otherwise, errors are ignored
     * \return
     */
-    void rs2_aus_decrement( const char * counter, rs2_error ** error );
+    void rs2_aus_decrement(const char* counter, rs2_error** error);
 
     /**
     * get counter value
@@ -46,7 +46,7 @@ extern "C" {
     * \param[out] error    if non-null, receives any error that occurs during this call, otherwise, errors are ignored
     * \return     counter value
     */
-    long rs2_aus_get( const char * counter, rs2_error ** error );
+    long rs2_aus_get(const char* counter, rs2_error** error);
 
     /**
     * starts timer
@@ -54,7 +54,7 @@ extern "C" {
     * \param[out] error    if non-null, receives any error that occurs during this call, otherwise, errors are ignored
     * \return
     */
-    void rs2_aus_start( const char * timer, rs2_error ** error );
+    void rs2_aus_start(const char* timer, rs2_error** error);
 
     /**
     * stops timer
@@ -62,7 +62,7 @@ extern "C" {
     * \param[out] error    if non-null, receives any error that occurs during this call, otherwise, errors are ignored
     * \return
     */
-    void rs2_aus_stop( const char * timer, rs2_error ** error );
+    void rs2_aus_stop(const char* timer, rs2_error** error);
 
 
     /**
@@ -70,7 +70,7 @@ extern "C" {
     * \param[out] error    if non-null, receives any error that occurs during this call, otherwise, errors are ignored
     * \return     struct that includes vector with counters names as strings
     */
-    const rs2_strings_list * rs2_aus_get_counters_list( rs2_error ** error );
+    const rs2_strings_list * rs2_aus_get_counters_list(rs2_error** error);
 
     /**
     * get size of rs2_aus_counters_names buffer
@@ -78,7 +78,7 @@ extern "C" {
     * \param[out] error    if non-null, receives any error that occurs during this call, otherwise, errors are ignored
     * \return     size of rs2_aus_counters_names buffer
     */
-    int rs2_aus_get_counters_list_size( const rs2_strings_list * buffer, rs2_error ** error );
+    int rs2_aus_get_counters_list_size(const rs2_strings_list* buffer, rs2_error** error);
 
     /**
     * delete rs2_aus_counters_names buffer
@@ -86,7 +86,7 @@ extern "C" {
     * \param[out] error    if non-null, receives any error that occurs during this call, otherwise, errors are ignored
     * \return
     */
-    void rs2_aus_delete_counters_list( const rs2_strings_list * buffer );
+    void rs2_aus_delete_counters_list(const rs2_strings_list* buffer);
 
     /**
     * Retrieve char array from rs2_aus_counters_names buffer at index i
@@ -94,9 +94,9 @@ extern "C" {
     * \param[out] error   if non-null, receives any error that occurs during this call, otherwise, errors are ignored
     * \return     char* from buffer at index i
     */
-    const char * rs2_aus_get_counter_data( const rs2_strings_list * buffer, int i, rs2_error ** error );
+    const char * rs2_aus_get_counter_data(const rs2_strings_list* buffer, int i, rs2_error** error);
 
-    const rs2_raw_data_buffer * rs2_aus_receive_json_data(rs2_error ** error);
+    const rs2_raw_data_buffer * rs2_aus_receive_json_data(rs2_error** error);
 
 #ifdef __cplusplus
 }

--- a/include/librealsense2/hpp/rs_aus.hpp
+++ b/include/librealsense2/hpp/rs_aus.hpp
@@ -74,6 +74,26 @@ namespace rs2
         return results;
     }
 
+    inline  std::vector<uint8_t> aus_receive_json_data( std::string json_content )
+    {
+        std::vector<uint8_t> results;
+
+        rs2_error * e = nullptr;
+        const rs2_raw_data_buffer * buf = rs2_aus_receive_json_data( &e );
+        error::handle(e);
+
+        std::shared_ptr<const rs2_raw_data_buffer> list( buf, rs2_delete_raw_data );
+        
+        auto size = rs2_get_raw_data_size( list.get(), &e );
+        error::handle(e);
+
+        auto start = rs2_get_raw_data( list.get(), &e );
+
+        results.insert( results.begin(), start, start + size );
+
+        return results;
+    }
+
 }
 
 #endif // LIBREALSENSE_RS2_AUS_HPP

--- a/src/aus.cpp
+++ b/src/aus.cpp
@@ -80,6 +80,11 @@ void librealsense::aus_on_device_changed( std::string serial, std::string name )
     aus_data_obj.on_device_changed( serial,name);
 }
 
+std::vector<uint8_t> librealsense::aus_get_data()
+{
+    return aus_data_obj.get_data();
+}
+
 
 #else // BUILD_AUS
 

--- a/src/aus.h
+++ b/src/aus.h
@@ -130,7 +130,7 @@ namespace librealsense
             _start_time = std::chrono::system_clock::to_time_t(std::chrono::system_clock::now());
             _librealsense_version = RS2_API_VERSION_STR;
             _os_name = rsutils::get_os_name();
-            _platform_name = PLATFORM;
+            _platform_name = rsutils::get_platform_name();
         }
 
         void set(std::string key, long value)
@@ -234,26 +234,6 @@ namespace librealsense
         std::string _librealsense_version;
         std::string _os_name;
         std::string _platform_name;
-
-        const char * PLATFORM =
-
-            #ifdef _WIN64
-            "Windows amd64";
-        #elif _WIN32
-            "Windows x86";
-        #elif __linux__
-            #ifdef __arm__
-            "Linux arm";
-        #else
-            "Linux amd64";
-        #endif
-        #elif __APPLE__
-            "Mac OS";
-        #elif __ANDROID__
-            "Linux arm";
-        #else
-            "";
-        #endif
 
         void assert_key_exists(std::string key)
         {

--- a/src/aus.h
+++ b/src/aus.h
@@ -4,6 +4,7 @@
 #pragma once
 
 #include "types.h"
+#include <rsutils/os/os.h>
 
 namespace librealsense
 {
@@ -128,29 +129,10 @@ namespace librealsense
         {
             _start_time = std::chrono::system_clock::to_time_t(std::chrono::system_clock::now());
             _librealsense_version = RS2_API_VERSION_STR;
-            _os_name = get_os_name();
+            _os_name = rsutils::get_os_name();
             _platform_name = PLATFORM;
-
         }
 
-        std::string get_os_name()
-        {
-            #ifdef _WIN32
-            return "Windows";
-            #else
-            #ifdef __APPLE__
-            return "Mac OS";
-            #else
-            #ifdef __linux__
-            return "Linux";
-            #else
-            return "Unknown";
-            #endif
-            #endif
-            #endif
-        }
-
-        
         void set(std::string key, long value)
         {
             if (_mp.find(key) != _mp.end())
@@ -241,7 +223,7 @@ namespace librealsense
             {
                 insert_device_to_device_manager( serial, name );
             }
-        } 
+        }
 
     private:
         std::unordered_map<std::string, aus_value*> _mp;

--- a/src/aus.h
+++ b/src/aus.h
@@ -5,6 +5,8 @@
 
 #include "types.h"
 #include <rsutils/os/os.h>
+#include <third-party/json.hpp>
+using nlohmann::json;
 
 namespace librealsense
 {
@@ -225,6 +227,20 @@ namespace librealsense
             }
         }
 
+        std::vector<std::uint8_t>  get_data()
+        {
+            json j;
+            j["librealsense_version"] = _start_time;
+            j["os_name"] = _librealsense_version;
+            j["platform_name"] = _os_name;
+
+            for ( const auto & pair : _mp )
+            {
+                j[pair.first] = std::to_string( pair.second->get() );
+            }
+            return json::to_ubjson( j );
+        }
+
     private:
         std::unordered_map<std::string, aus_value*> _mp;
         std::unordered_map<std::string, std::string > _mp_devices_manager;
@@ -234,6 +250,8 @@ namespace librealsense
         std::string _librealsense_version;
         std::string _os_name;
         std::string _platform_name;
+
+        //json jsn;
 
         void assert_key_exists(std::string key)
         {

--- a/src/realsense.def
+++ b/src/realsense.def
@@ -165,6 +165,7 @@ EXPORTS
     rs2_aus_get_counters_list_size
     rs2_aus_delete_counters_list
     rs2_aus_get_counter_data
+    rs2_aus_receive_json_data
 
     rs2_get_log_message_line_number
     rs2_get_log_message_filename

--- a/src/rs.cpp
+++ b/src/rs.cpp
@@ -462,6 +462,13 @@ const char * rs2_aus_get_counter_data( const rs2_strings_list * buffer, int i, r
 }
 HANDLE_EXCEPTIONS_AND_RETURN( 0, buffer )
 
+const rs2_raw_data_buffer * rs2_aus_receive_json_data( rs2_error ** error ) BEGIN_API_CALL
+{
+    std::vector<uint8_t> buffer_aus_data_recieved = librealsense::aus_get_data();
+    return new rs2_raw_data_buffer { buffer_aus_data_recieved };
+}
+NOARGS_HANDLE_EXCEPTIONS_AND_RETURN( 0 );
+
 // librealsense wrapper around a C function
 class calibration_change_callback : public rs2_calibration_change_callback
 {

--- a/src/types.h
+++ b/src/types.h
@@ -217,7 +217,8 @@ namespace librealsense
     std::string aus_build_system_counter_name(std::string suffix, std::string device_name = "");
     std::vector<std::string> aus_get_counters_list();
     void aus_on_device_changed( std::string serial,std::string name);
-
+    std::vector<uint8_t> aus_get_data();
+    
     // Enhancement for debug mode that incurs performance penalty with STL
     // std::clamp to be introduced with c++17
     template< typename T>

--- a/third-party/rsutils/include/rsutils/os/os.h
+++ b/third-party/rsutils/include/rsutils/os/os.h
@@ -1,0 +1,10 @@
+// License: Apache 2.0. See LICENSE file in root directory.
+// Copyright(c) 2017 Intel Corporation. All Rights Reserved.
+
+#pragma once
+#include <string>
+
+namespace rsutils
+{
+    std::string get_os_name();
+}

--- a/third-party/rsutils/include/rsutils/os/os.h
+++ b/third-party/rsutils/include/rsutils/os/os.h
@@ -7,4 +7,5 @@
 namespace rsutils
 {
     std::string get_os_name();
+    std::string get_platform_name();
 }

--- a/third-party/rsutils/src/os.cpp
+++ b/third-party/rsutils/src/os.cpp
@@ -1,0 +1,24 @@
+// License: Apache 2.0. See LICENSE file in root directory.
+// Copyright(c) 2017 Intel Corporation. All Rights Reserved.
+
+#include <rsutils/os/os.h>
+
+namespace rsutils
+{
+    std::string get_os_name()
+    {
+#ifdef _WIN32
+        return "Windows";
+#else
+#ifdef __APPLE__
+        return "Mac OS";
+#else
+#ifdef __linux__
+        return "Linux";
+#else
+        return "Unknown";
+#endif
+#endif
+#endif
+    }  
+}

--- a/third-party/rsutils/src/os.cpp
+++ b/third-party/rsutils/src/os.cpp
@@ -20,5 +20,27 @@ namespace rsutils
 #endif
 #endif
 #endif
-    }  
+    } 
+
+std::string get_platform_name()
+    {
+#ifdef _WIN64
+    return "Windows amd64";
+#elif _WIN32
+    return "Windows x86";
+#elif __linux__
+    #ifdef __arm__
+    return "Linux arm";
+#else
+    return "Linux amd64";
+#endif
+#elif __APPLE__
+    return "Mac OS";
+#elif __ANDROID__
+    return "Linux arm";
+#else
+    return "";
+#endif
+
+    }
 }


### PR DESCRIPTION
Aus - adding OS common capabilities to utilities library
moving  "get_os_name" func to rsutils library
create get_platform_name in os.cpp in rsutils library

LRS-578